### PR TITLE
Rename control 2.6 to reduce confusion

### DIFF
--- a/src/mvsp.en.asciidoc
+++ b/src/mvsp.en.asciidoc
@@ -86,7 +86,7 @@ h| Description
 
   Example: ORM for database access, UI framework for rendering DOM
 
-| 2.6 Patching
+| 2.6 Dependency Patching
 | Apply security patches with a severity score of "medium" or higher, or ensure equivalent mitigations are available for all components of the application stack within one month of the patch release
 
 | 2.7 Logging


### PR DESCRIPTION
Patching as a title is not explicit enough and causes confusion about what the control referes to. Renaming to "Dependency Patching" should reflect that it refers to fixes in the supply chain.

fixes #5 