### PR TITLE
Update 2.2 to remove includesubdomains

### DIFF
--- a/packages/mvsp/mvsp-alpha.en.asciidoc
+++ b/packages/mvsp/mvsp-alpha.en.asciidoc
@@ -63,7 +63,8 @@ h| Description
   This does not apply to secure protocols designed to run on top of unencrypted connections, such as OCSP
 
   * Scan and address issues using freely available modern TLS scanning tools
-  * Include the Strict-Transport-Security header with the `includeSubdomains` directive
+  * Include the Strict-Transport-Security header with a long `max-age` value
+
   * Set authentication cookies as Secure
 
 | 2.3 Security Headers


### PR DESCRIPTION
Correct 2.2 to `Include the Strict-Transport-Security header with a long `max-age` value` as discussed