### PR TITLE
Minor wording clarification in prior art

### DIFF
--- a/packages/website/src/_includes/index/prior-art.html
+++ b/packages/website/src/_includes/index/prior-art.html
@@ -31,7 +31,7 @@
         <div class="lg:grid lg:grid-cols-1 lg:gap-6">
           <div class="prose prose-cadillac prose-lg text-gray-900 lg:max-w-none">
             <p>Part of the motivation for MVSP was driven by Dropbox'
-              <a href="https://github.com/dropbox/vsmc">Vendor Security Model Contract (VSMC)</a>, and the Google's <a
+              <a href="https://github.com/dropbox/vsmc">Vendor Security Model Contract (VSMC)</a>, and Google's <a
                 href="https://github.com/google/vsaq">Vendor Security Assessment Questionnaire (VSAQ)</a>.
             </p>
             <p>We have analyzed multiple existing master agreements, as well as taking experience from mature vendor


### PR DESCRIPTION
Remove `the` from `and the Google's Vendor Security Assessment Questionnaire (VSAQ).`